### PR TITLE
Delete Eur3kA and FlappyPig

### DIFF
--- a/teams.dot
+++ b/teams.dot
@@ -341,9 +341,6 @@ digraph teams {
     "excusemewtf" -> "organizers";
     "the cr0wn" -> "organizers";
 
-    // r3kapig
-    "Eur3kA" -> "r3kapig";
-    "FlappyPig" -> "r3kapig";
   }
 
   // level 4 -> level 3


### PR DESCRIPTION
Since it has been active under the name of r3kapig since 2018 and the other two teams(Eur3kA and FlappyPig) are no longer active, it will be deleted without further merger

https://twitter.com/CrazymanArmy/status/1663404910615068672
https://twitter.com/brokenpacifist/status/1663459133801254912
